### PR TITLE
fixed syntactical errors in HTML code

### DIFF
--- a/MiniCalculator.html
+++ b/MiniCalculator.html
@@ -1,33 +1,29 @@
+<!DOCTYPE html>
 <html>
 
 <head>
-<title>MiniCalculator</title>
+    <title>MiniCalculator</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <style>
         body {
-
             background-color: #818181;
-
         }
-
+        
         .content {
             padding: 500px 500px;
         }
-
+        
         .button {
             color: black;
             padding: 15px 32px;
             text-align: center;
             font-size: 20px;
             margin: 4px 2px;
-
         }
-
+        
         .inp {
-
             height: 60px;
             font-size: 29px;
-
             direction: rtl;
         }
     </style>
@@ -46,16 +42,14 @@
             }
 
 
-        } 
+        }
     </script>
-    <title>Simple Calculator</title>
 </head>
 
 <body>
     <div class="content">
 
-        <iframe src="https://docs.google.com/gview?url=http://fppt.com/myfile.ppt&embedded=true" style="width:600px;"
-            frameborder="0"></iframe>
+        <iframe src="https://docs.google.com/gview?url=http://fppt.com/myfile.ppt&embedded=true" style="width:600px; border: 0"></iframe>
 
         <table>
             <tr>
@@ -104,6 +98,5 @@
 
     </div>
 </body>
-</head>
 
 </html>


### PR DESCRIPTION
Fixed HTML Syntactical errors in MiniClaculator.html
- Start tag seen without seeing a doctype first. Expected: <!DOCTYPE html>
- Saw an end tag after “body” had been closed. Stray end tag “head”.
- Element “title” not allowed as child of element “head” in this context [Line 51].
- The “frameborder” attribute on the “iframe” element is obsolete. Used CSS instead.

